### PR TITLE
Menus: Remove `$_menu_item_sort_prop` global reference from `wp_get_n…

### DIFF
--- a/wp-includes/nav-menu.php
+++ b/wp-includes/nav-menu.php
@@ -636,7 +636,6 @@ function _is_valid_nav_menu_item( $item ) {
  *
  * @since 3.0.0
  *
- * @global string $_menu_item_sort_prop
  * @staticvar array $fetched
  *
  * @param int|string|WP_Term $menu Menu ID, slug, name, or object.

--- a/wp-includes/version.php
+++ b/wp-includes/version.php
@@ -4,7 +4,7 @@
  *
  * @global string $wp_version
  */
-$wp_version = '5.0-alpha-42633';
+$wp_version = '5.0-alpha-42634';
 
 /**
  * Holds the WordPress DB revision, increments when changes are made to the WordPress DB schema.


### PR DESCRIPTION
…av_menu_items()`, unused since [38928].

Props PieWP, welcher.
Fixes #40947.
Built from https://develop.svn.wordpress.org/trunk@42634


git-svn-id: http://core.svn.wordpress.org/trunk@42463 1a063a9b-81f0-0310-95a4-ce76da25c4cd